### PR TITLE
chore: add support ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,28 +53,15 @@ jobs:
     strategy:
       matrix:
         os:
-          # - ubuntu-1404
-          - ubuntu-1604
           - ubuntu-1804
           - ubuntu-2004
           - ubuntu-2204
+          - ubuntu-2404
         suite:
-          # - default-chef13
-          - default-chef14
-          - default-chef15
-          - default-chef16
           - default-chef17
           - default-chef18
-          - custom-chef13
-          - custom-chef14
-          - custom-chef15
-          - custom-chef16
           - custom-chef17
           - custom-chef18
-          - disabled-chef13
-          - disabled-chef14
-          - disabled-chef15
-          - disabled-chef16
           - disabled-chef17
           - disabled-chef18
       # include:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,7 +43,7 @@ platforms:
 
 
 chef17: &chef17 '17.10.0'
-chef18: &chef18 '18.4.12'
+chef18: &chef18 '18.3.0'
 
 suites:
   - name: default-chef17

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ driver:
   pull_chef_image: false
   pull_platform_image: false
   clean_dokken_sandbox: false
+  pid_one_command: /bin/systemd
   intermediate_instructions:
     - RUN /usr/bin/apt-get update --fix-missing
   use_cache: true
@@ -27,35 +28,27 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-14.04
-    driver:
-      image: dokken/ubuntu-14.04
-      pid_one_command: /sbin/init
-      cap_add:
-        - SYS_ADMIN
-  - name: ubuntu-16.04
-    driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /bin/systemd
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
-      pid_one_command: /bin/systemd
+  - name: ubuntu-22.04
+    driver:
+      image: dokken/ubuntu-22.04
 
-chef18: &chef18 '18.3.0'
+
+chef17: &chef17 '17.10.0'
+chef18: &chef18 '18.4.12'
 
 suites:
-  - name: default-chef13
+  - name: default-chef17
     driver:
-      chef_version: '13'
+      chef_version: *chef17
     verifier: &default_verifier
       inspec_tests:
         - test/integration/default/inspec
@@ -65,38 +58,6 @@ suites:
     run_list: &default_runlist
       - recipe[ntpdate]
 
-  - name: default-chef14
-    driver:
-      chef_version: '14'
-    verifier:
-      <<: *default_verifier
-    run_list:
-      - *default_runlist
-
-  - name: default-chef15
-    driver:
-      chef_version: '15'
-    verifier:
-      <<: *default_verifier
-    run_list:
-      - *default_runlist
-
-  - name: default-chef16
-    driver:
-      chef_version: '16'
-    verifier:
-      <<: *default_verifier
-    run_list:
-      - *default_runlist
-
-  - name: default-chef17
-    driver:
-      chef_version: '17.1.35'
-    verifier:
-      <<: *default_verifier
-    run_list:
-      - *default_runlist
-
   - name: default-chef18
     driver:
       chef_version: *chef18
@@ -105,9 +66,9 @@ suites:
     run_list:
       - *default_runlist
 
-  - name: custom-chef13
+  - name: custom-chef17
     driver:
-      chef_version: '13'
+      chef_version: *chef17
     verifier: &custom_verifier
       inspec_tests:
         - test/integration/custom/inspec
@@ -130,59 +91,19 @@ suites:
           hour: 6
           weekday: sun
 
-  - name: custom-chef14
-    driver:
-      chef_version: '14'
-    verifier:
-      <<: *custom_verifier
-    run_list:
-      - *default_runlist
-    attributes:
-      <<: *custom_attributes
-
-  - name: custom-chef15
-    driver:
-      chef_version: '15'
-    verifier:
-      <<: *custom_verifier
-    run_list:
-      - *default_runlist
-    attributes:
-      <<: *custom_attributes
-
-  - name: custom-chef16
-    driver:
-      chef_version: '16'
-    verifier:
-      <<: *custom_verifier
-    run_list:
-      - *default_runlist
-    attributes:
-      <<: *custom_attributes
-
-  - name: custom-chef17
-    driver:
-      chef_version: '17.1.35'
-    verifier:
-      <<: *custom_verifier
-    run_list:
-      - recipe[ntpdate]
-    attributes:
-      <<: *custom_attributes
-
   - name: custom-chef18
     driver:
       chef_version: *chef18
     verifier:
       <<: *custom_verifier
     run_list:
-      - recipe[ntpdate]
+      - *default_runlist
     attributes:
       <<: *custom_attributes
 
-  - name: disabled-chef13
+  - name: disabled-chef17
     driver:
-      chef_version: '13'
+      chef_version: *chef17
     verifier: &disabled_verifier
       inspec_tests:
         - test/integration/disabled/inspec
@@ -205,52 +126,12 @@ suites:
           hour: 6
           day: 7
 
-  - name: disabled-chef14
-    driver:
-      chef_version: '14'
-    verifier:
-      <<: *disabled_verifier
-    run_list:
-      - *default_runlist
-    attributes:
-      <<: *disabled_attributes
-
-  - name: disabled-chef15
-    driver:
-      chef_version: '15'
-    verifier:
-      <<: *disabled_verifier
-    run_list:
-      - *default_runlist
-    attributes:
-      <<: *disabled_attributes
-
-  - name: disabled-chef16
-    driver:
-      chef_version: '16'
-    verifier:
-      <<: *disabled_verifier
-    run_list:
-      - *default_runlist
-    attributes:
-      <<: *disabled_attributes
-
-  - name: disabled-chef17
-    driver:
-      chef_version: '17.1.35'
-    verifier:
-      <<: *disabled_verifier
-    run_list:
-      - recipe[ntpdate]
-    attributes:
-      <<: *disabled_attributes
-
   - name: disabled-chef18
     driver:
       chef_version: *chef18
     verifier:
       <<: *disabled_verifier
     run_list:
-      - recipe[ntpdate]
+      - *default_runlist
     attributes:
       <<: *disabled_attributes

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,13 +37,12 @@ platforms:
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
-  - name: ubuntu-22.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-22.04
+      image: dokken/ubuntu-24.04
 
-
-chef17: &chef17 '17.10.0'
-chef18: &chef18 '18.3.0'
+chef17: &chef17 '17'
+chef18: &chef18 '18'
 
 suites:
   - name: default-chef17

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 ---
 AllCops:
   TargetRubyVersion: 2.6
-RegexpLiteral:
+Style/RegexpLiteral:
   EnforcedStyle: percent_r

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ntpdate CHANGELOG
 =================
 
+1.7.0
+-----
+
+- added tests for `Ubuntu 24.04`
+- removed EOL `chef`/`Ubuntu X.Y` tests.
+
 1.6.0
 -----
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Ivan Golman'
 maintainer_email 'ivan.golman@gmail.com'
 license          'Apache-2.0'
 description      'Installs/Configures ntpdate'
-version          '1.6.0'
+version          '1.7.0'
 
 issues_url       'https://github.com/igolman/ntpdate/issues'
 source_url       'https://github.com/igolman/ntpdate'


### PR DESCRIPTION
1.7.0
-----

- added tests for `Ubuntu 24.04`
- removed EOL `chef`/`Ubuntu X.Y` tests.