### PR TITLE
chore: add tests for chef v19/ubuntu 26.04, drop chef v17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,14 @@ jobs:
           - ubuntu-2004
           - ubuntu-2204
           - ubuntu-2404
+          - ubuntu-2604
         suite:
-          - default-chef17
           - default-chef18
-          - custom-chef17
+          - default-chef19
           - custom-chef18
-          - disabled-chef17
+          - custom-chef19
           - disabled-chef18
+          - disabled-chef19
       # include:
       #   - os: ubuntu-2004
       #     suite: openjdk-pkg-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,37 @@ jobs:
           - custom-chef19
           - disabled-chef18
           - disabled-chef19
-      # include:
-      #   - os: ubuntu-2004
-      #     suite: openjdk-pkg-14
-      # exclude:
-      #   - os: debian-9
-      #     suite: openjdk-pkg-11
-      #   - os: debian-10
-      #     suite: openjdk-pkg-8
+        exclude:
+          - os: ubuntu-1804
+            suite: default-chef19
+          - os: ubuntu-1804
+            suite: custom-chef19
+          - os: ubuntu-1804
+            suite: disabled-chef19
+          - os: ubuntu-2004
+            suite: default-chef19
+          - os: ubuntu-2004
+            suite: custom-chef19
+          - os: ubuntu-2004
+            suite: disabled-chef19
+          - os: ubuntu-2204
+            suite: default-chef19
+          - os: ubuntu-2204
+            suite: custom-chef19
+          - os: ubuntu-2204
+            suite: disabled-chef19
+          - os: ubuntu-2404
+            suite: default-chef19
+          - os: ubuntu-2404
+            suite: custom-chef19
+          - os: ubuntu-2404
+            suite: disabled-chef19
+          - os: ubuntu-2604
+            suite: default-chef18
+          - os: ubuntu-2604
+            suite: custom-chef18
+          - os: ubuntu-2604
+            suite: disabled-chef18
       fail-fast: false
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
       - name: Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: kitchen-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-1804
           - ubuntu-2004
           - ubuntu-2204
           - ubuntu-2404
@@ -66,12 +65,6 @@ jobs:
           - disabled-chef18
           - disabled-chef19
         exclude:
-          - os: ubuntu-1804
-            suite: default-chef19
-          - os: ubuntu-1804
-            suite: custom-chef19
-          - os: ubuntu-1804
-            suite: disabled-chef19
           - os: ubuntu-2004
             suite: default-chef19
           - os: ubuntu-2004

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,16 +6,18 @@ driver:
   privileged: true
   pull_chef_image: false
   pull_platform_image: false
-  clean_dokken_sandbox: false
+  clean_dokken_sandbox: true
   pid_one_command: /bin/systemd
   intermediate_instructions:
     - RUN /usr/bin/apt-get update --fix-missing
   use_cache: true
   hostname: ntpdate.example.com
+  chef_image: cincproject/cinc
 
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  chef_binary: /opt/cinc/bin/chef-client
   multiple_converge: 2
   enforce_idempotency: true
   client_rb:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,14 +40,19 @@ platforms:
   - name: ubuntu-24.04
     driver:
       image: dokken/ubuntu-24.04
+  - name: ubuntu-26.04
+    driver:
+      image: dokken/ubuntu-26.04
+      pid_one_command: /usr/lib/systemd/systemd
 
-chef17: &chef17 '17'
+
 chef18: &chef18 '18'
+chef19: &chef19 '19'
 
 suites:
-  - name: default-chef17
+  - name: default-chef18
     driver:
-      chef_version: *chef17
+      chef_version: *chef18
     verifier: &default_verifier
       inspec_tests:
         - test/integration/default/inspec
@@ -57,17 +62,17 @@ suites:
     run_list: &default_runlist
       - recipe[ntpdate]
 
-  - name: default-chef18
+  - name: default-chef19
     driver:
-      chef_version: *chef18
+      chef_version: *chef19
     verifier:
       <<: *default_verifier
     run_list:
       - *default_runlist
 
-  - name: custom-chef17
+  - name: custom-chef18
     driver:
-      chef_version: *chef17
+      chef_version: *chef18
     verifier: &custom_verifier
       inspec_tests:
         - test/integration/custom/inspec
@@ -90,9 +95,9 @@ suites:
           hour: 6
           weekday: sun
 
-  - name: custom-chef18
+  - name: custom-chef19
     driver:
-      chef_version: *chef18
+      chef_version: *chef19
     verifier:
       <<: *custom_verifier
     run_list:
@@ -100,9 +105,9 @@ suites:
     attributes:
       <<: *custom_attributes
 
-  - name: disabled-chef17
+  - name: disabled-chef18
     driver:
-      chef_version: *chef17
+      chef_version: *chef18
     verifier: &disabled_verifier
       inspec_tests:
         - test/integration/disabled/inspec
@@ -125,9 +130,9 @@ suites:
           hour: 6
           day: 7
 
-  - name: disabled-chef18
+  - name: disabled-chef19
     driver:
-      chef_version: *chef18
+      chef_version: *chef19
     verifier:
       <<: *disabled_verifier
     run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,9 +28,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,7 +44,7 @@ platforms:
 
 
 chef18: &chef18 '18'
-chef19: &chef19 '19'
+chef19: &chef19 '19.2.12'
 
 suites:
   - name: default-chef18

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,8 +4,8 @@ driver:
   provision: true
   use_sudo: false
   privileged: true
-  pull_chef_image: false
-  pull_platform_image: false
+  pull_chef_image: true
+  pull_platform_image: true
   clean_dokken_sandbox: true
   pid_one_command: /bin/systemd
   intermediate_instructions:
@@ -17,7 +17,7 @@ driver:
 provisioner:
   name: dokken
   deprecations_as_errors: true
-  chef_binary: /opt/cinc/bin/chef-client
+  chef_binary: /opt/cinc/bin/cinc-client
   multiple_converge: 2
   enforce_idempotency: true
   client_rb:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ntpdate CHANGELOG
 =================
 
+1.8.0
+-----
+
+- added tests for `Ubuntu 26.04`
+- removed EOL `chef v17 tests.
+
 1.7.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ ntpdate CHANGELOG
 -----
 
 - added tests for `Ubuntu 26.04`
-- removed EOL `chef v17` tests.
+- removed EOL `chef v17` and `ubuntu 18.04` tests.
 
 1.7.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ ntpdate CHANGELOG
 -----
 
 - added tests for `Ubuntu 26.04`
-- removed EOL `chef v17 tests.
+- removed EOL `chef v17` tests.
 
 1.7.0
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,8 @@ default['ntpdate']['config_folder'] = '/etc/default'
 default['ntpdate']['config_file'] = 'ntpdate'
 default['ntpdate']['ntp_servers'] = %w(pool.ntp.org)
 default['ntpdate']['ntp_options'] = nil
-default['ntpdate']['package_name'] = %w(ntpdate)
+default['ntpdate']['package_name'] =
+  Gem::Version.new(node["platform_version"]) > Gem::Version.new('24.04') ? %w(ntpsec-ntpdate) : %w(ntpdate)
 default['ntpdate']['crontab']['minute'] = '0'
 default['ntpdate']['crontab']['hour'] = '5'
 default['ntpdate']['crontab']['day'] = '*'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default['ntpdate']['config_file'] = 'ntpdate'
 default['ntpdate']['ntp_servers'] = %w(pool.ntp.org)
 default['ntpdate']['ntp_options'] = nil
 default['ntpdate']['package_name'] =
-  Gem::Version.new(node["platform_version"]) > Gem::Version.new('24.04') ? %w(ntpsec-ntpdate) : %w(ntpdate)
+  Gem::Version.new(node['platform_version']) > Gem::Version.new('24.04') ? %w(ntpsec-ntpdate) : %w(ntpdate)
 default['ntpdate']['crontab']['minute'] = '0'
 default['ntpdate']['crontab']['hour'] = '5'
 default['ntpdate']['crontab']['day'] = '*'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Ivan Golman'
 maintainer_email 'ivan.golman@gmail.com'
 license          'Apache-2.0'
 description      'Installs/Configures ntpdate'
-version          '1.7.0'
+version          '1.8.0'
 
 issues_url       'https://github.com/igolman/ntpdate/issues'
 source_url       'https://github.com/igolman/ntpdate'

--- a/test/integration/custom/inspec/default_spec.rb
+++ b/test/integration/custom/inspec/default_spec.rb
@@ -1,5 +1,9 @@
-describe package('ntpdate') do
-  it { should be_installed }
+ntp_packages = Gem::Version.new(os[:release]) > Gem::Version.new('24.04') ? %w(ntpsec-ntpdate) : %w(ntpdate)
+
+ntp_packages.each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
 end
 
 describe file('/etc/default/ntpdate') do

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,5 +1,9 @@
-describe package('ntpdate') do
-  it { should be_installed }
+ntp_packages = Gem::Version.new(os[:release]) > Gem::Version.new('24.04') ? %w(ntpsec-ntpdate) : %w(ntpdate)
+
+ntp_packages.each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
 end
 
 describe file('/etc/default/ntpdate') do


### PR DESCRIPTION
1.8.0
-----

- added tests for `Ubuntu 26.04`
- removed EOL `chef v17` tests.
